### PR TITLE
PCP-7057: Bump Go builder to 1.26.4 to fix CVEs

### DIFF
--- a/.github/workflows/spectro-release.yaml
+++ b/.github/workflows/spectro-release.yaml
@@ -62,8 +62,8 @@ jobs:
         name: Build Image
         env:
           REGISTRY: ${{ env.LEGACY_REGISTRY }}
-          GO_VERSION: 1.26.3
-          BUILDER_GOLANG_VERSION: 1.26.3
+          GO_VERSION: 1.26.4
+          BUILDER_GOLANG_VERSION: 1.26.4
         run: |
           make docker-build-all
           make docker-push-all
@@ -73,8 +73,8 @@ jobs:
           FIPS_ENABLE: yes
           REGISTRY: ${{ env.FIPS_REGISTRY }}
           ALL_ARCH: amd64
-          GO_VERSION: 1.26.3
-          BUILDER_GOLANG_VERSION: 1.26.3
+          GO_VERSION: 1.26.4
+          BUILDER_GOLANG_VERSION: 1.26.4
         run: |
           make docker-build-all
           make docker-push-all


### PR DESCRIPTION
PCP-7057: Bump Go builder to 1.26.4 to fix CVEs